### PR TITLE
Fix Unicode encoding issue when writing to output file

### DIFF
--- a/src/repo2txt/repo2txt.py
+++ b/src/repo2txt/repo2txt.py
@@ -319,7 +319,7 @@ def main():
         doc.add_heading("<-- File Content Ends", level=2)
         doc.save(args.output_file)
     else:
-        with open(args.output_file, 'w') as output_file:
+        with open(args.output_file, 'w', encoding='utf-8') as output_file:
             output_file.write("Repository Documentation\n")
             output_file.write(
             "This document provides a comprehensive overview of the repository's structure and contents.\n"


### PR DESCRIPTION
Fix Unicode encoding issue when writing to output file

- Specify UTF-8 encoding when opening the output file in text mode
- Resolve the issue of 'charmap' codec not being able to encode certain characters
- Ensure proper handling of Unicode characters in the generated output file

The script now explicitly uses the UTF-8 encoding when writing to the output file. This fixes the UnicodeEncodeError that occurred when the default Windows-1252 encoding encountered unsupported characters.

By specifying 'encoding='utf-8'' when opening the file, the script can now correctly write Unicode characters to the output file without any encoding errors.